### PR TITLE
Add tests for 100% coverage of Repository.Person.equals() - Fix #17

### DIFF
--- a/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
+++ b/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
@@ -43,13 +43,17 @@ import static org.junit.jupiter.api.Assertions.*;
  * by {@link org.springframework.data.jpa.domain.Specification} are also test.
  *
  * Previously tested requirements of Person.equals() (Coverage 24%) :
- * -
+ * - Comparision of age.
+ * - Positive instance, when compared objects are equal.
  Previously untested but now tested requirements of Person.equals() (Coverage 100%):
- * - Compares identity
- * - If the input object is Null
- * - If the input object is not of class Person
- * - Compares firstName, lastName and address (both positive and negative tests)
- * - If firstName, lastName or address is Null (edited)
+ * - Positive instances:
+ *    - Compare object to self.
+ *    - Compare equal objects that don't have first names or surnames.
+ * - Negative instances:
+ *    - Compare non-equal first names, surnames and id's.
+ *    - Compare if one Person-object's first name, surname or id is null.
+ *    - If input object is null.
+ *    - If the input object is not of class Person.
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:applicationContext.xml" })
@@ -131,13 +135,11 @@ public class RepositoryTest {
    */
   @Test
   public void testEqualsPositive() {
-    //Comparision with self
     Person p1 = new Person("John", "Johnsson", 20);
-    assertTrue(p1.equals(p1));
-
-    //Comparision with other equal object
     Person p2 = new Person("John", "Johnsson", 20);
-    assertTrue(p1.equals(p2));
+
+    //Comparision with self
+    assertTrue(p1.equals(p1));
 
     //Two Person-objects with no names
     p1.setName(null);
@@ -168,11 +170,6 @@ public class RepositoryTest {
     p2 = new Person("John", "Ericsson", 20);
     assertFalse(p1.equals(p2));
 
-    //Different ages
-    p1 = new Person("John", "Johnsson", 20);
-    p2 = new Person("John", "Johnsson", 21);
-    assertFalse(p1.equals(p2));
-
     //One person has id, not the other
     p2 = new Person("John", "Johnsson", 20);
     p1.setId((long) 1);
@@ -192,14 +189,7 @@ public class RepositoryTest {
 
     //No surname for one person
     p1 = new Person("John", "Johnsson", 20);
-    p2 = new Person("John", "Johnsson", 20);
     p1.setSurname(null);
-    assertFalse(p1.equals(p2));
-    assertFalse(p2.equals(p1));
-
-    //Empty constructor case
-    p1 = new Person();
-    p2 = new Person("John", "Johnsson", 20);
     assertFalse(p1.equals(p2));
     assertFalse(p2.equals(p1));
 

--- a/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
+++ b/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
@@ -22,10 +22,6 @@
  */
 package com.iluwatar.repository;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Arrays;
 import java.util.List;
 
@@ -39,6 +35,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import com.google.common.collect.Lists;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Test case to test the functions of {@link PersonRepository}, beside the CRUD functions, the query
@@ -119,9 +117,59 @@ public class RepositoryTest {
     assertEquals(terry, actual);
   }
 
+  @Test
+  public void testEqualsPositive() {
+    Person p1 = new Person("John", "Johnsson", 20);
+    assertTrue(p1.equals(p1));
+
+    Person p2 = new Person("John", "Johnsson", 20);
+    assertTrue(p1.equals(p2));
+  }
+
+  @Test
+  public void testEqualsNegative() {
+
+    //Different first name
+    Person p1 = new Person("John", "Johnsson", 20);
+    Person p2 = new Person("Eric", "Johnsson", 20);
+    assertFalse(p1.equals(p2));
+
+    //Different surname
+    p1 = new Person("John", "Johnsson", 20);
+    p2 = new Person("John", "Ericsson", 20);
+    assertFalse(p1.equals(p2));
+
+    //Different age
+    p1 = new Person("John", "Johnsson", 20);
+    p2 = new Person("John", "Johnsson", 21);
+    assertFalse(p1.equals(p2));
+
+    //Different id
+    p2 = new Person("John", "Johnsson", 20);
+    p1.setId((long) 1);
+    assertFalse(p1.equals(p2));
+    assertFalse(p2.equals(p1));
+
+    p2.setId((long) 2);
+    assertFalse(p1.equals(p2));
+
+    //Empty constructor case
+    p1 = new Person();
+    p2 = new Person("John", "Johnsson", 20);
+    assertFalse(p1.equals(p2));
+    assertFalse(p2.equals(p1));
+
+    //null-comparision
+    assertFalse(p1.equals(null));
+
+    //Other class comparision
+    int notAPerson = 1;
+    assertFalse(p2.equals(notAPerson));
+
+  }
+
   @AfterEach
   public void cleanup() {
-
     repository.deleteAll();
   }
 

--- a/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
+++ b/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
@@ -124,6 +124,17 @@ public class RepositoryTest {
 
     Person p2 = new Person("John", "Johnsson", 20);
     assertTrue(p1.equals(p2));
+
+    //No names for both persons
+    p1.setName(null);
+    p2.setName(null);
+    assertTrue(p1.equals(p2));
+
+    p1.setName("John");
+    p2.setName("John");
+    p1.setSurname(null);
+    p2.setSurname(null);
+    assertTrue(p1.equals(p2));
   }
 
   @Test
@@ -152,6 +163,20 @@ public class RepositoryTest {
 
     p2.setId((long) 2);
     assertFalse(p1.equals(p2));
+
+    //No first name for one person
+    p1 = new Person("John", "Johnsson", 20);
+    p2 = new Person("John", "Johnsson", 20);
+    p1.setName(null);
+    assertFalse(p1.equals(p2));
+    assertFalse(p2.equals(p1));
+
+    //No surname for one person
+    p1 = new Person("John", "Johnsson", 20);
+    p2 = new Person("John", "Johnsson", 20);
+    p1.setSurname(null);
+    assertFalse(p1.equals(p2));
+    assertFalse(p2.equals(p1));
 
     //Empty constructor case
     p1 = new Person();

--- a/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
+++ b/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
@@ -41,6 +41,15 @@ import static org.junit.jupiter.api.Assertions.*;
 /**
  * Test case to test the functions of {@link PersonRepository}, beside the CRUD functions, the query
  * by {@link org.springframework.data.jpa.domain.Specification} are also test.
+ *
+ * Previously tested requirements of Person.equals() (Coverage 24%) :
+ * -
+ Previously untested but now tested requirements of Person.equals() (Coverage 100%):
+ * - Compares identity
+ * - If the input object is Null
+ * - If the input object is not of class Person
+ * - Compares firstName, lastName and address (both positive and negative tests)
+ * - If firstName, lastName or address is Null (edited)
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(locations = { "classpath:applicationContext.xml" })
@@ -117,50 +126,60 @@ public class RepositoryTest {
     assertEquals(terry, actual);
   }
 
+  /**
+   * Tests positive instances for method Person.equals()
+   */
   @Test
   public void testEqualsPositive() {
+    //Comparision with self
     Person p1 = new Person("John", "Johnsson", 20);
     assertTrue(p1.equals(p1));
 
+    //Comparision with other equal object
     Person p2 = new Person("John", "Johnsson", 20);
     assertTrue(p1.equals(p2));
 
-    //No names for both persons
+    //Two Person-objects with no names
     p1.setName(null);
     p2.setName(null);
     assertTrue(p1.equals(p2));
 
     p1.setName("John");
     p2.setName("John");
+    //Two Person-objects with no surnames
     p1.setSurname(null);
     p2.setSurname(null);
     assertTrue(p1.equals(p2));
   }
 
+  /**
+   * Tests negative instances for method Person.equals()
+   */
   @Test
   public void testEqualsNegative() {
 
-    //Different first name
+    //Different first names
     Person p1 = new Person("John", "Johnsson", 20);
     Person p2 = new Person("Eric", "Johnsson", 20);
     assertFalse(p1.equals(p2));
 
-    //Different surname
+    //Different surnames
     p1 = new Person("John", "Johnsson", 20);
     p2 = new Person("John", "Ericsson", 20);
     assertFalse(p1.equals(p2));
 
-    //Different age
+    //Different ages
     p1 = new Person("John", "Johnsson", 20);
     p2 = new Person("John", "Johnsson", 21);
     assertFalse(p1.equals(p2));
 
-    //Different id
+    //One person has id, not the other
     p2 = new Person("John", "Johnsson", 20);
     p1.setId((long) 1);
     assertFalse(p1.equals(p2));
     assertFalse(p2.equals(p1));
 
+    //Different ids
     p2.setId((long) 2);
     assertFalse(p1.equals(p2));
 
@@ -187,7 +206,7 @@ public class RepositoryTest {
     //null-comparision
     assertFalse(p1.equals(null));
 
-    //Other class comparision
+    //Comparision with object from other class
     int notAPerson = 1;
     assertFalse(p2.equals(notAPerson));
 

--- a/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
+++ b/repository/src/test/java/com/iluwatar/repository/RepositoryTest.java
@@ -134,21 +134,24 @@ public class RepositoryTest {
    * Tests positive instances for method Person.equals()
    */
   @Test
-  public void testEqualsPositive() {
+  public void compareToSelf() {
+    Person p1 = new Person("John", "Johnsson", 20);
+    assertTrue(p1.equals(p1));
+  }
+
+  @Test
+  public void testEqualNullNames() {
     Person p1 = new Person("John", "Johnsson", 20);
     Person p2 = new Person("John", "Johnsson", 20);
-
-    //Comparision with self
-    assertTrue(p1.equals(p1));
-
-    //Two Person-objects with no names
     p1.setName(null);
     p2.setName(null);
     assertTrue(p1.equals(p2));
+  }
 
-    p1.setName("John");
-    p2.setName("John");
-    //Two Person-objects with no surnames
+  @Test
+  public void testEqualNullSurnames() {
+    Person p1 = new Person("John", "Johnsson", 20);
+    Person p2 = new Person("John", "Johnsson", 20);
     p1.setSurname(null);
     p2.setSurname(null);
     assertTrue(p1.equals(p2));
@@ -158,48 +161,65 @@ public class RepositoryTest {
    * Tests negative instances for method Person.equals()
    */
   @Test
-  public void testEqualsNegative() {
-
-    //Different first names
+  public void testDifferentNames() {
     Person p1 = new Person("John", "Johnsson", 20);
     Person p2 = new Person("Eric", "Johnsson", 20);
     assertFalse(p1.equals(p2));
+  }
 
-    //Different surnames
-    p1 = new Person("John", "Johnsson", 20);
-    p2 = new Person("John", "Ericsson", 20);
+  @Test
+  public void testDifferentSurnames() {
+    Person p1 = new Person("John", "Johnsson", 20);
+    Person p2 = new Person("John", "Ericsson", 20);
     assertFalse(p1.equals(p2));
+  }
 
-    //One person has id, not the other
-    p2 = new Person("John", "Johnsson", 20);
+  @Test
+  public void testNoId() {
+    Person p1 = new Person("John", "Johnsson", 20);
+    Person p2 = new Person("John", "Johnsson", 20);
     p1.setId((long) 1);
     assertFalse(p1.equals(p2));
     assertFalse(p2.equals(p1));
+  }
 
-    //Different ids
+  @Test
+  public void testDifferentIds() {
+    Person p1 = new Person("John", "Johnsson", 20);
+    Person p2 = new Person("John", "Johnsson", 20);
     p2.setId((long) 2);
     assertFalse(p1.equals(p2));
+  }
 
-    //No first name for one person
-    p1 = new Person("John", "Johnsson", 20);
-    p2 = new Person("John", "Johnsson", 20);
+  @Test
+  public void testNameIsNull() {
+    Person p1 = new Person("John", "Johnsson", 20);
+    Person p2 = new Person("John", "Johnsson", 20);
     p1.setName(null);
     assertFalse(p1.equals(p2));
     assertFalse(p2.equals(p1));
+  }
 
-    //No surname for one person
-    p1 = new Person("John", "Johnsson", 20);
+  @Test
+  public void testSurnameIsNull() {
+    Person p1 = new Person("John", "Johnsson", 20);
+    Person p2 = new Person("John", "Johnsson", 20);
     p1.setSurname(null);
     assertFalse(p1.equals(p2));
     assertFalse(p2.equals(p1));
+  }
 
-    //null-comparision
+  @Test
+  public void testObjectIsNull() {
+    Person p1 = new Person("John", "Johnsson", 20);
     assertFalse(p1.equals(null));
+  }
 
-    //Comparision with object from other class
+  @Test
+  public void testNonPersonObject() {
+    Person p1 = new Person("John", "Johnsson", 20);
     int notAPerson = 1;
-    assertFalse(p2.equals(notAPerson));
-
+    assertFalse(p1.equals(notAPerson));
   }
 
   @AfterEach


### PR DESCRIPTION
Add tests to RepositoryTest to improve coverage on method Person.equals.

Previously tested requirements of Person.equals() (Coverage 24%) :
- Comparision of age.
- Positive instance, when compared objects are equal.
 Previously untested but now tested requirements of Person.equals() (Coverage 100%):
- Positive instances:
    - Compare object to self.
    - Compare equal objects that don't have first names or surnames.
- Negative instances:
    - Compare non-equal first names, surnames and id's.
    - Compare if one Person-object's first name, surname or id is null.
    - If input object is null.
    - If the input object is not of class Person.
 