### PR TITLE
Add test for QuadTree.insert - Fix #12

### DIFF
--- a/spatial-partition/src/test/java/com/iluwatar/spatialpartition/QuadTreeTest.java
+++ b/spatial-partition/src/test/java/com/iluwatar/spatialpartition/QuadTreeTest.java
@@ -35,6 +35,19 @@ import org.junit.jupiter.api.Test;
 
 class QuadTreeTest {
 
+  /**
+   * Test that point outside of field area is not inserted into the tree.
+   */
+  @Test
+  void testPointOutsideField() {
+    Rect field = new Rect(150,150,300,300); //size of field
+    ArrayList<Point> points = new ArrayList<Point>();
+    Bubble p = new Bubble(1000, 1000, 1,1);
+    points.add(p);
+    Rect queryRange = new Rect(150,150,300,300); //result = all points lying in this rectangle
+    assertNull(QuadTreeTest.quadTreeTest(points, field, queryRange).get(1));
+  }
+
   @Test
   void queryTest() {
     ArrayList<Point> points = new ArrayList<Point>();

--- a/spatial-partition/src/test/java/com/iluwatar/spatialpartition/QuadTreeTest.java
+++ b/spatial-partition/src/test/java/com/iluwatar/spatialpartition/QuadTreeTest.java
@@ -37,6 +37,7 @@ class QuadTreeTest {
 
   /**
    * Test that point outside of field area is not inserted into the tree.
+   * Covers the case when QuadTree.insert() should return and stop recursive tree search.
    */
   @Test
   void testPointOutsideField() {

--- a/spatial-partition/src/test/java/com/iluwatar/spatialpartition/QuadTreeTest.java
+++ b/spatial-partition/src/test/java/com/iluwatar/spatialpartition/QuadTreeTest.java
@@ -31,8 +31,11 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Testing QuadTree class.
+ * Previously tested requirements of QuadTree.insert() (Coverage 86%) :
+ * - Checking that points inserted within the field can be found in the right spot.
+ Previously untested but now tested requirements of Person.equals() (Coverage 93%):
+ * - Checking that points inserted outside the field can't be found.
  */
-
 class QuadTreeTest {
 
   /**


### PR DESCRIPTION
Add test for QuadTree.insert() to QuadTreeTest.

Previously tested requirements of QuadTree.insert() (Coverage 86%) :
 - Checking that points inserted within the field can be found in the right spot.
 Previously untested but now tested requirements of Person.equals() (Coverage 93%):
 - Checking that points inserted outside the field can't be found.
